### PR TITLE
supported "as" for pkg alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ var pkg = require('gulp-packages')(gulp, [
   'less',
   'coffee',
   'pleeease',
-  'minifyCss',
+  'minify-css',//MUST call it by pkg.minifyCss()
+  'html-minifier as minHtm',//call it by pkg.minHtm(),pkg.htmlMinifier DOESN'T work!
   'uglify',
   'rename',
   'watch',
@@ -78,7 +79,7 @@ var pkg = require('gulp-packages')(gulp, [
   'less',
   'coffee',
   'pleeease',
-  'minifyCss',
+  'minify-css',
   'uglify',      // <- not installed yet
   'rename',      // <- not installed yet 
   'watch',
@@ -112,7 +113,7 @@ var pkg = require('gulp-packages')(gulp, [
   'less',
   'coffee',
   'pleeease',
-  'minifyCss',
+  'minify-css',
   'watch',
   'coffeelint',
 ]);
@@ -156,12 +157,14 @@ $ gulp uninstall
 ## Package name rule
 
 1. Remove 'gulp-'
-2. Convert to camel case
+2. Convert to camel case when call it
+3. "as" overwrites call name for shorter or else
 
 ### Example
-
-* gulp-uglify -> 'uglify'
-* gulp-minify-css -> 'minifyCss'
+gulp-name -> pkg-name / call-name
+* gulp-uglify -> 'uglify' / uglify()
+* gulp-minify-css -> 'minify-css' / minifyCss()              //MUST call it by pkg.minifyCss()
+* gulp-html-minifier -> 'html-minifier as minHtm' / minHtm() //call it by pkg.htmlMinifier() DOESN'T work!
 
 ## Changelog
 

--- a/gulp-packages.js
+++ b/gulp-packages.js
@@ -7,13 +7,13 @@ module.exports = function (gulp,packages) {
   var clc = require('cli-color');
   var cwd = process.cwd();
   var camel=function(str){
-    return str.replace(/-([a-z])/g, function (match, char) { return char.toUpperCase(); })
+    return str.replace(/-(\w)/g, function (match, char) { return char.toUpperCase(); })
   }
   for (var i = 0; i < packages.length; i++) {
-    var pkg=packages[i].split(/\bas\b/,2);
+    var pkg=packages[i].split(/\sas\s/,2);
     pkg[1]=camel(pkg[pkg.length==2?1:0]);
     packages[i]=pkg[0];
-    m = 'gulp-' + pkg[0]//.replace(/([A-Z])/g, '-$1').toLowerCase();
+    var m = 'gulp-' + pkg[0]//.replace(/([A-Z])/g, '-$1').toLowerCase();
     try {
       _pkgs.loaded[pkg[1]] = require(cwd + '/node_modules/' + m);
     } catch (e) {

--- a/gulp-packages.js
+++ b/gulp-packages.js
@@ -1,18 +1,18 @@
 /*jshint node:true,loopfunc:true*/
-module.exports = function (gulp, packages) {
+module.exports = function (gulp,packages) {
   'use strict';
 
-  gulp._packages = { notInstalled: [], loaded: {} };
+  var pkg = { notInstalled: [], loaded: {} };
 
   var clc = require('cli-color');
   var cwd = process.cwd();
 
   for (var i = 0; i < packages.length; i++) {
-    var m=packages[i].match(/([\w|-]+)[\bas\b]?([\w|-]+)[\S]/g)
-    if(m.length==1) m[1]=m[0]
+    var m=packages[i].match(/([\w|-]+)[\bas\b]?([\w]+)[\S]/g)
+    if(m.length==1) m[1]=m[0].replace(/-([a-z])/g, function (m, p) { return p.toUpperCase(); })
     m[0] = 'gulp-' + m[0].replace(/([A-Z])/g, '-$1').toLowerCase();
     try {
-      gulp._packages.loaded[m[1]] = require(cwd + '/node_modules/' + m[0]);
+      pkg.loaded[m[1]] = require(cwd + '/node_modules/' + m[0]);
     } catch (e) {
       gulp._packages.notInstalled.push(m[0]);
     }
@@ -52,8 +52,8 @@ module.exports = function (gulp, packages) {
     var installed = Object.keys(require(cwd + '/package.json').devDependencies || {});
     var toUninstall = [];
     for (var i = 0; i < installed.length; i++) {
-      if (! /^gulp-/.test(installed[i])) { continue; }
-      var m = installed[i].substr(5).replace(/-([a-z])/g, function (m, p) { return p.toUpperCase(); });
+      if (! /^gulp-/.test(installed[i])) continue;
+      var m = installed[i].substr(5);
       if (packages.indexOf(m) === -1 && m !== 'packages') { toUninstall.push(installed[i]); }
     }
     npmCommand('uninstall', toUninstall, cb);

--- a/gulp-packages.js
+++ b/gulp-packages.js
@@ -8,11 +8,13 @@ module.exports = function (gulp, packages) {
   var cwd = process.cwd();
 
   for (var i = 0; i < packages.length; i++) {
-    var m = 'gulp-' + packages[i].replace(/([A-Z])/g, '-$1').toLowerCase();
+    var m=packages[i].match(/([\w|-]+)[\bas\b]?([\w|-]+)[\S]/g)
+    if(m.length==1) m[1]=m[0]
+    m[0] = 'gulp-' + m[0].replace(/([A-Z])/g, '-$1').toLowerCase();
     try {
-      gulp._packages.loaded[packages[i]] = require(cwd + '/node_modules/' + m);
+      gulp._packages.loaded[m[1]] = require(cwd + '/node_modules/' + m[0]);
     } catch (e) {
-      gulp._packages.notInstalled.push(m);
+      gulp._packages.notInstalled.push(m[0]);
     }
   }
 


### PR DESCRIPTION
Convert to camel case when call it
html-minifier as minHtm',//call it by pkg.minHtm()

Example:
gulp-name -> pkg-name / call-name
- gulp-uglify -> 'uglify' / uglify()
- gulp-minify-css -> 'minify-css' / minifyCss()              //MUST call it by pkg.minifyCss()
- gulp-html-minifier -> 'html-minifier as minHtm' / minHtm() //call it by pkg.htmlMinifier() DOESN'T work!
